### PR TITLE
Make igbinary/msgpack optional

### DIFF
--- a/Formula/relay.rb
+++ b/Formula/relay.rb
@@ -111,9 +111,8 @@ class Relay < Formula
       The configuration file was symlinked to:
         #{conf_dir}/ext-relay.ini
 
-      The `igbinary` and `msgpack` extensions are optional. They're only needed
-      to use Relay's igbinary/msgpack serializers and are detected at runtime.
-      Install them if desired using `\033[32mpecl install igbinary\033[0m` and `\033[32mpecl install msgpack\033[0m`.
+      The `igbinary` (recommended) and `msgpack` extensions are optional.
+      Install them using `\033[32mpecl install igbinary\033[0m`.
 
       Run `\033[32mphp --ri relay\033[0m` to ensure Relay is working.
 

--- a/Formula/relay.rb
+++ b/Formula/relay.rb
@@ -48,7 +48,7 @@ class Relay < Formula
     php = (Formula["php"].opt_bin/"php").to_s
     extensions = Utils.safe_popen_read(php, "-m")
 
-    ["json", "igbinary", "msgpack"].each do |name|
+    ["json"].each do |name|
       unless /^#{name}/.match?(extensions)
         raise "Relay requires the `#{name}` extension. Install it using `\033[32mpecl install #{name}\033[0m`."
       end
@@ -110,6 +110,10 @@ class Relay < Formula
 
       The configuration file was symlinked to:
         #{conf_dir}/ext-relay.ini
+
+      The `igbinary` and `msgpack` extensions are optional. They're only needed
+      to use Relay's igbinary/msgpack serializers and are detected at runtime.
+      Install them if desired using `\033[32mpecl install igbinary\033[0m` and `\033[32mpecl install msgpack\033[0m`.
 
       Run `\033[32mphp --ri relay\033[0m` to ensure Relay is working.
 

--- a/Formula/relay@8.0.rb
+++ b/Formula/relay@8.0.rb
@@ -52,7 +52,7 @@ class RelayAT80 < Formula
 
     extensions = Utils.safe_popen_read(php, "-m")
 
-    ["json", "igbinary", "msgpack"].each do |name|
+    ["json"].each do |name|
       unless /^#{name}/.match?(extensions)
         raise "Relay requires the `#{name}` extension. Install it using `\033[32m#{pecl} install #{name}\033[0m`."
       end
@@ -108,6 +108,10 @@ class RelayAT80 < Formula
 
       The configuration file was symlinked to:
         #{conf_dir}/ext-relay.ini
+
+      The `igbinary` and `msgpack` extensions are optional. They're only needed
+      to use Relay's igbinary/msgpack serializers and are detected at runtime.
+      Install them if desired using `\033[32m#{pecl} install igbinary\033[0m` and `\033[32m#{pecl} install msgpack\033[0m`.
 
       Run `\033[32mphp --ri relay\033[0m` to ensure Relay is working.
 

--- a/Formula/relay@8.0.rb
+++ b/Formula/relay@8.0.rb
@@ -109,9 +109,8 @@ class RelayAT80 < Formula
       The configuration file was symlinked to:
         #{conf_dir}/ext-relay.ini
 
-      The `igbinary` and `msgpack` extensions are optional. They're only needed
-      to use Relay's igbinary/msgpack serializers and are detected at runtime.
-      Install them if desired using `\033[32m#{pecl} install igbinary\033[0m` and `\033[32m#{pecl} install msgpack\033[0m`.
+      The `igbinary` (recommended) and `msgpack` extensions are optional.
+      Install them using `\033[32m#{pecl} install igbinary\033[0m`.
 
       Run `\033[32mphp --ri relay\033[0m` to ensure Relay is working.
 

--- a/Formula/relay@8.1.rb
+++ b/Formula/relay@8.1.rb
@@ -109,9 +109,8 @@ class RelayAT81 < Formula
       The configuration file was symlinked to:
         #{conf_dir}/ext-relay.ini
 
-      The `igbinary` and `msgpack` extensions are optional. They're only needed
-      to use Relay's igbinary/msgpack serializers and are detected at runtime.
-      Install them if desired using `\033[32m#{pecl} install igbinary\033[0m` and `\033[32m#{pecl} install msgpack\033[0m`.
+      The `igbinary` (recommended) and `msgpack` extensions are optional.
+      Install them using `\033[32m#{pecl} install igbinary\033[0m`.
 
       Run `\033[32mphp --ri relay\033[0m` to ensure Relay is working.
 

--- a/Formula/relay@8.1.rb
+++ b/Formula/relay@8.1.rb
@@ -52,7 +52,7 @@ class RelayAT81 < Formula
 
     extensions = Utils.safe_popen_read(php, "-m")
 
-    ["json", "igbinary", "msgpack"].each do |name|
+    ["json"].each do |name|
       unless /^#{name}/.match?(extensions)
         raise "Relay requires the `#{name}` extension. Install it using `\033[32m#{pecl} install #{name}\033[0m`."
       end
@@ -108,6 +108,10 @@ class RelayAT81 < Formula
 
       The configuration file was symlinked to:
         #{conf_dir}/ext-relay.ini
+
+      The `igbinary` and `msgpack` extensions are optional. They're only needed
+      to use Relay's igbinary/msgpack serializers and are detected at runtime.
+      Install them if desired using `\033[32m#{pecl} install igbinary\033[0m` and `\033[32m#{pecl} install msgpack\033[0m`.
 
       Run `\033[32mphp --ri relay\033[0m` to ensure Relay is working.
 

--- a/Formula/relay@8.2.rb
+++ b/Formula/relay@8.2.rb
@@ -109,9 +109,8 @@ class RelayAT82 < Formula
       The configuration file was symlinked to:
         #{conf_dir}/ext-relay.ini
 
-      The `igbinary` and `msgpack` extensions are optional. They're only needed
-      to use Relay's igbinary/msgpack serializers and are detected at runtime.
-      Install them if desired using `\033[32m#{pecl} install igbinary\033[0m` and `\033[32m#{pecl} install msgpack\033[0m`.
+      The `igbinary` (recommended) and `msgpack` extensions are optional.
+      Install them using `\033[32m#{pecl} install igbinary\033[0m`.
 
       Run `\033[32mphp --ri relay\033[0m` to ensure Relay is working.
 

--- a/Formula/relay@8.2.rb
+++ b/Formula/relay@8.2.rb
@@ -52,7 +52,7 @@ class RelayAT82 < Formula
 
     extensions = Utils.safe_popen_read(php, "-m")
 
-    ["json", "igbinary", "msgpack"].each do |name|
+    ["json"].each do |name|
       unless /^#{name}/.match?(extensions)
         raise "Relay requires the `#{name}` extension. Install it using `\033[32m#{pecl} install #{name}\033[0m`."
       end
@@ -108,6 +108,10 @@ class RelayAT82 < Formula
 
       The configuration file was symlinked to:
         #{conf_dir}/ext-relay.ini
+
+      The `igbinary` and `msgpack` extensions are optional. They're only needed
+      to use Relay's igbinary/msgpack serializers and are detected at runtime.
+      Install them if desired using `\033[32m#{pecl} install igbinary\033[0m` and `\033[32m#{pecl} install msgpack\033[0m`.
 
       Run `\033[32mphp --ri relay\033[0m` to ensure Relay is working.
 

--- a/Formula/relay@8.3.rb
+++ b/Formula/relay@8.3.rb
@@ -52,7 +52,7 @@ class RelayAT83 < Formula
 
     extensions = Utils.safe_popen_read(php, "-m")
 
-    ["json", "igbinary", "msgpack"].each do |name|
+    ["json"].each do |name|
       unless /^#{name}/.match?(extensions)
         raise "Relay requires the `#{name}` extension. Install it using `\033[32m#{pecl} install #{name}\033[0m`."
       end
@@ -108,6 +108,10 @@ class RelayAT83 < Formula
 
       The configuration file was symlinked to:
         #{conf_dir}/ext-relay.ini
+
+      The `igbinary` and `msgpack` extensions are optional. They're only needed
+      to use Relay's igbinary/msgpack serializers and are detected at runtime.
+      Install them if desired using `\033[32m#{pecl} install igbinary\033[0m` and `\033[32m#{pecl} install msgpack\033[0m`.
 
       Run `\033[32mphp --ri relay\033[0m` to ensure Relay is working.
 

--- a/Formula/relay@8.3.rb
+++ b/Formula/relay@8.3.rb
@@ -109,9 +109,8 @@ class RelayAT83 < Formula
       The configuration file was symlinked to:
         #{conf_dir}/ext-relay.ini
 
-      The `igbinary` and `msgpack` extensions are optional. They're only needed
-      to use Relay's igbinary/msgpack serializers and are detected at runtime.
-      Install them if desired using `\033[32m#{pecl} install igbinary\033[0m` and `\033[32m#{pecl} install msgpack\033[0m`.
+      The `igbinary` (recommended) and `msgpack` extensions are optional.
+      Install them using `\033[32m#{pecl} install igbinary\033[0m`.
 
       Run `\033[32mphp --ri relay\033[0m` to ensure Relay is working.
 

--- a/Formula/relay@8.4.rb
+++ b/Formula/relay@8.4.rb
@@ -105,9 +105,8 @@ class RelayAT84 < Formula
       The configuration file was symlinked to:
         #{conf_dir}/ext-relay.ini
 
-      The `igbinary` and `msgpack` extensions are optional. They're only needed
-      to use Relay's igbinary/msgpack serializers and are detected at runtime.
-      Install them if desired using `\033[32mpecl install igbinary\033[0m` and `\033[32mpecl install msgpack\033[0m`.
+      The `igbinary` (recommended) and `msgpack` extensions are optional.
+      Install them using `\033[32mpecl install igbinary\033[0m`.
 
       Run `\033[32mphp --ri relay\033[0m` to ensure Relay is working.
 

--- a/Formula/relay@8.4.rb
+++ b/Formula/relay@8.4.rb
@@ -48,7 +48,7 @@ class RelayAT84 < Formula
     php = (Formula["php"].opt_bin/"php").to_s
     extensions = Utils.safe_popen_read(php, "-m")
 
-    ["json", "igbinary", "msgpack"].each do |name|
+    ["json"].each do |name|
       unless /^#{name}/.match?(extensions)
         raise "Relay requires the `#{name}` extension. Install it using `\033[32mpecl install #{name}\033[0m`."
       end
@@ -104,6 +104,10 @@ class RelayAT84 < Formula
 
       The configuration file was symlinked to:
         #{conf_dir}/ext-relay.ini
+
+      The `igbinary` and `msgpack` extensions are optional. They're only needed
+      to use Relay's igbinary/msgpack serializers and are detected at runtime.
+      Install them if desired using `\033[32mpecl install igbinary\033[0m` and `\033[32mpecl install msgpack\033[0m`.
 
       Run `\033[32mphp --ri relay\033[0m` to ensure Relay is working.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ brew install cachewerk/tap/relay      # PHP 8.5
 brew install cachewerk/tap/relay@7.4  # PHP 7.4
 ```
 
-The installation might abort and you'll be prompted to install some PHP extensions that Relay requires. You can install them using PECL:
+The `igbinary` and `msgpack` PHP extensions are optional. They're only needed if you want to use Relay's igbinary or msgpack serializers, and Relay detects them at runtime — it loads and works fine without them. If you'd like to use those serializers, you can install the extensions using PECL:
 
 ```bash
 pecl install msgpack

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ brew install cachewerk/tap/relay      # PHP 8.5
 brew install cachewerk/tap/relay@7.4  # PHP 7.4
 ```
 
-The `igbinary` and `msgpack` PHP extensions are optional. They're only needed if you want to use Relay's igbinary or msgpack serializers, and Relay detects them at runtime — it loads and works fine without them. If you'd like to use those serializers, you can install the extensions using PECL:
+The `igbinary` and `msgpack` PHP extensions are optional, however using the `igbinary` serializer is recommended. Install the extensions using PECL:
 
 ```bash
-pecl install msgpack
 pecl install igbinary
+# pecl install msgpack
 ```
 
 After the installation is completed, be sure to restart your PHP-FPM and web server services:


### PR DESCRIPTION
`igbinary` and `msgpack` are now **optional** for Relay. As of the recent relay-core change, both serializers are compiled into Relay but **resolved at runtime** (bound via `dlsym` at module startup): if the extension is loaded the matching serializer is available, and if not, Relay still loads and works without it. `json` and `session` remain required.

- Narrow the install-time check from `["json", "igbinary", "msgpack"]` to `["json"]` in all 6 formulae, so `brew install relay` no longer aborts when igbinary/msgpack are absent.
- Note in each formula's caveats (and the README) that igbinary/msgpack are optional and only needed for the matching serializers.

Part of a cross-repo sweep updating references that still treated these extensions as hard requirements.