### PR TITLE
Drop Intel support for macOS builds

### DIFF
--- a/.github/workflows/bump-stable.yml
+++ b/.github/workflows/bump-stable.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           artifacts=$(
             curl -sS --fail "https://builds.r2.relay.so/$TAG_NAME/artifacts.json" \
-            | jq -r '.[] | select(.os == "darwin") | .url'
+            | jq -r '.[] | select(.os == "darwin" and .arch == "arm64") | .url'
           )
 
           for artifact in $artifacts; do
@@ -54,9 +54,9 @@ jobs:
             MARKER=$(echo $f | cut -d - -f 3- | gsed 's/.tar.gz//')
             URL="https://builds.r2.relay.so/$TAG_NAME/$f"
             echo "Setting URL for stable $MARKER marker to $URL"
-            gsed -i "/.*# stable: $MARKER/!b;n;c\ \ \ \ \ \ \ \ url \"$URL\"" Formula/*.rb
+            gsed -i "/.*# stable: $MARKER/!b;n;c\ \ \ \ \ \ url \"$URL\"" Formula/*.rb
             echo "Setting checksum for stable $MARKER marker to $HASH"
-            gsed -i "/.*# stable: $MARKER/!b;n;n;c\ \ \ \ \ \ \ \ sha256 \"$HASH\"" Formula/*.rb
+            gsed -i "/.*# stable: $MARKER/!b;n;n;c\ \ \ \ \ \ sha256 \"$HASH\"" Formula/*.rb
           done
 
       - name: Check formula style

--- a/Formula/relay.rb
+++ b/Formula/relay.rb
@@ -8,15 +8,9 @@ class Relay < Formula
     url "https://github.com/cachewerk/relay.git", tag: "v0.40.0"
 
     resource "ext-relay" do
-      if Hardware::CPU.arm?
-        # stable: php8.5-darwin-arm64
-        url "https://builds.r2.relay.so/v0.40.0/relay-v0.40.0-php8.5-darwin-arm64.tar.gz"
-        sha256 "d331f5443d94ab9b86e139d4b18cec62051d52c86c28d5349336dd346efbb1df"
-      else
-        # stable: php8.5-darwin-x86-64
-        url "https://builds.r2.relay.so/v0.9.0/relay-v0.7.0-php8.5-darwin-x86-64.tar.gz"
-        sha256 "bd94daaeb6aea3b53624b397502c26bb687ebc1b566699b4437f4a92e2f25606"
-      end
+      # stable: php8.5-darwin-arm64
+      url "https://builds.r2.relay.so/v0.40.0/relay-v0.40.0-php8.5-darwin-arm64.tar.gz"
+      sha256 "d331f5443d94ab9b86e139d4b18cec62051d52c86c28d5349336dd346efbb1df"
     end
   end
 
@@ -24,21 +18,14 @@ class Relay < Formula
     url "https://github.com/cachewerk/relay.git", branch: "main"
 
     resource "ext-relay" do
-      if Hardware::CPU.arm?
-        # head: php8.5-darwin-arm64
-        url "https://builds.r2.relay.so/dev/relay-dev-php8.5-darwin-arm64.tar.gz"
-      else
-        # head: php8.5-darwin-x86-64
-        url "https://builds.r2.relay.so/dev/relay-dev-php8.5-darwin-x86-64.tar.gz"
-      end
+      # head: php8.5-darwin-arm64
+      url "https://builds.r2.relay.so/dev/relay-dev-php8.5-darwin-arm64.tar.gz"
     end
   end
 
   depends_on "concurrencykit"
   depends_on "hiredis"
-  depends_on "lz4"
   depends_on "php"
-  depends_on "zstd"
 
   def conf_dir
     Pathname(Utils.safe_popen_read(formula_opt_bin("php")/"php-config", "--ini-dir").chomp)
@@ -63,21 +50,19 @@ class Relay < Formula
       # relink dependencies
       dylibs = MachO::Tools.dylibs("relay.so")
 
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis\./).first, (formula_opt_lib("hiredis")/"libhiredis.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis_ssl\./).first, (formula_opt_lib("hiredis")/"libhiredis_ssl.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libssl/).first, (formula_opt_lib("openssl")/"libssl.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libcrypto/).first, (formula_opt_lib("openssl")/"libcrypto.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libzstd/).first, (formula_opt_lib("zstd")/"libzstd.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/liblz4/).first, (formula_opt_lib("lz4")/"liblz4.dylib").to_s)
-
-      if Hardware::CPU.intel?
-        MachO::Tools.change_install_name("relay.so", dylibs.grep(/libck/).first, (formula_opt_lib("ck")/"libck.dylib").to_s)
+      {
+        /libhiredis\./     => formula_opt_lib("hiredis")/"libhiredis.dylib",
+        /libhiredis_ssl\./ => formula_opt_lib("hiredis")/"libhiredis_ssl.dylib",
+        /libssl/           => formula_opt_lib("openssl")/"libssl.dylib",
+        /libcrypto/        => formula_opt_lib("openssl")/"libcrypto.dylib",
+        /libck/            => formula_opt_lib("ck")/"libck.dylib",
+      }.each do |pattern, new_name|
+        old_name = dylibs.grep(pattern).first
+        MachO::Tools.change_install_name("relay.so", old_name, new_name.to_s) if old_name
       end
 
       # Apply ad-hoc code signature
-      MachO.codesign!("relay.so") if Hardware::CPU.arm?
+      MachO.codesign!("relay.so")
 
       # move extension file
       lib.install "relay.so"

--- a/Formula/relay@8.0.rb
+++ b/Formula/relay@8.0.rb
@@ -8,15 +8,9 @@ class RelayAT80 < Formula
     url "https://github.com/cachewerk/relay.git", tag: "v0.40.0"
 
     resource "ext-relay" do
-      if Hardware::CPU.arm?
-        # stable: php8.0-darwin-arm64
-        url "https://builds.r2.relay.so/v0.40.0/relay-v0.40.0-php8.0-darwin-arm64.tar.gz"
-        sha256 "4481728e6c55c8d180c2f70445c5b377bb67f9a688200ff96c9b920a81100420"
-      else
-        # stable: php8.0-darwin-x86-64
-        url "https://builds.r2.relay.so/v0.7.0/relay-v0.7.0-php8.0-darwin-x86-64.tar.gz"
-        sha256 "addde9b76376d9b1786bc38ec24b08eca26347dd48a311f09372dc2ae1d2a55d"
-      end
+      # stable: php8.0-darwin-arm64
+      url "https://builds.r2.relay.so/v0.40.0/relay-v0.40.0-php8.0-darwin-arm64.tar.gz"
+      sha256 "4481728e6c55c8d180c2f70445c5b377bb67f9a688200ff96c9b920a81100420"
     end
   end
 
@@ -24,13 +18,8 @@ class RelayAT80 < Formula
     url "https://github.com/cachewerk/relay.git", branch: "main"
 
     resource "ext-relay" do
-      if Hardware::CPU.arm?
-        # head: php8.0-darwin-arm64
-        url "https://builds.r2.relay.so/dev/relay-dev-php8.0-darwin-arm64.tar.gz"
-      else
-        # head: php8.0-darwin-x86-64
-        url "https://builds.r2.relay.so/dev/relay-dev-php8.0-darwin-x86-64.tar.gz"
-      end
+      # head: php8.0-darwin-arm64
+      url "https://builds.r2.relay.so/dev/relay-dev-php8.0-darwin-arm64.tar.gz"
     end
   end
 
@@ -38,9 +27,7 @@ class RelayAT80 < Formula
 
   depends_on "concurrencykit"
   depends_on "hiredis"
-  depends_on "lz4"
   depends_on "php@8.0"
-  depends_on "zstd"
 
   def conf_dir
     Pathname(Utils.safe_popen_read(formula_opt_bin("php@8.0")/"php-config", "--ini-dir").chomp)
@@ -67,21 +54,19 @@ class RelayAT80 < Formula
       # relink dependencies
       dylibs = MachO::Tools.dylibs("relay.so")
 
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis\./).first, (formula_opt_lib("hiredis")/"libhiredis.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis_ssl\./).first, (formula_opt_lib("hiredis")/"libhiredis_ssl.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libssl/).first, (formula_opt_lib("openssl")/"libssl.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libcrypto/).first, (formula_opt_lib("openssl")/"libcrypto.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libzstd/).first, (formula_opt_lib("zstd")/"libzstd.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/liblz4/).first, (formula_opt_lib("lz4")/"liblz4.dylib").to_s)
-
-      if Hardware::CPU.intel?
-        MachO::Tools.change_install_name("relay.so", dylibs.grep(/libck/).first, (formula_opt_lib("ck")/"libck.dylib").to_s)
+      {
+        /libhiredis\./     => formula_opt_lib("hiredis")/"libhiredis.dylib",
+        /libhiredis_ssl\./ => formula_opt_lib("hiredis")/"libhiredis_ssl.dylib",
+        /libssl/           => formula_opt_lib("openssl")/"libssl.dylib",
+        /libcrypto/        => formula_opt_lib("openssl")/"libcrypto.dylib",
+        /libck/            => formula_opt_lib("ck")/"libck.dylib",
+      }.each do |pattern, new_name|
+        old_name = dylibs.grep(pattern).first
+        MachO::Tools.change_install_name("relay.so", old_name, new_name.to_s) if old_name
       end
 
       # Apply ad-hoc code signature
-      MachO.codesign!("relay.so") if Hardware::CPU.arm?
+      MachO.codesign!("relay.so")
 
       # move extension file
       lib.install "relay.so"

--- a/Formula/relay@8.1.rb
+++ b/Formula/relay@8.1.rb
@@ -8,15 +8,9 @@ class RelayAT81 < Formula
     url "https://github.com/cachewerk/relay.git", tag: "v0.40.0"
 
     resource "ext-relay" do
-      if Hardware::CPU.arm?
-        # stable: php8.1-darwin-arm64
-        url "https://builds.r2.relay.so/v0.40.0/relay-v0.40.0-php8.1-darwin-arm64.tar.gz"
-        sha256 "a70aaeb363f5ec38ab106ab06dee42aa5219f889cfac81db5146dc80b962f2b7"
-      else
-        # stable: php8.1-darwin-x86-64
-        url "https://builds.r2.relay.so/v0.7.0/relay-v0.7.0-php8.1-darwin-x86-64.tar.gz"
-        sha256 "63f9a866b05ee2ba28401490292f2f3c24e3be21cacb83bb7784f5903dee742e"
-      end
+      # stable: php8.1-darwin-arm64
+      url "https://builds.r2.relay.so/v0.40.0/relay-v0.40.0-php8.1-darwin-arm64.tar.gz"
+      sha256 "a70aaeb363f5ec38ab106ab06dee42aa5219f889cfac81db5146dc80b962f2b7"
     end
   end
 
@@ -24,13 +18,8 @@ class RelayAT81 < Formula
     url "https://github.com/cachewerk/relay.git", branch: "main"
 
     resource "ext-relay" do
-      if Hardware::CPU.arm?
-        # head: php8.1-darwin-arm64
-        url "https://builds.r2.relay.so/dev/relay-dev-php8.1-darwin-arm64.tar.gz"
-      else
-        # head: php8.1-darwin-x86-64
-        url "https://builds.r2.relay.so/dev/relay-dev-php8.1-darwin-x86-64.tar.gz"
-      end
+      # head: php8.1-darwin-arm64
+      url "https://builds.r2.relay.so/dev/relay-dev-php8.1-darwin-arm64.tar.gz"
     end
   end
 
@@ -38,9 +27,7 @@ class RelayAT81 < Formula
 
   depends_on "concurrencykit"
   depends_on "hiredis"
-  depends_on "lz4"
   depends_on "php@8.1"
-  depends_on "zstd"
 
   def conf_dir
     Pathname(Utils.safe_popen_read(formula_opt_bin("php@8.1")/"php-config", "--ini-dir").chomp)
@@ -67,21 +54,19 @@ class RelayAT81 < Formula
       # relink dependencies
       dylibs = MachO::Tools.dylibs("relay.so")
 
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis\./).first, (formula_opt_lib("hiredis")/"libhiredis.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis_ssl\./).first, (formula_opt_lib("hiredis")/"libhiredis_ssl.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libssl/).first, (formula_opt_lib("openssl")/"libssl.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libcrypto/).first, (formula_opt_lib("openssl")/"libcrypto.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libzstd/).first, (formula_opt_lib("zstd")/"libzstd.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/liblz4/).first, (formula_opt_lib("lz4")/"liblz4.dylib").to_s)
-
-      if Hardware::CPU.intel?
-        MachO::Tools.change_install_name("relay.so", dylibs.grep(/libck/).first, (formula_opt_lib("ck")/"libck.dylib").to_s)
+      {
+        /libhiredis\./     => formula_opt_lib("hiredis")/"libhiredis.dylib",
+        /libhiredis_ssl\./ => formula_opt_lib("hiredis")/"libhiredis_ssl.dylib",
+        /libssl/           => formula_opt_lib("openssl")/"libssl.dylib",
+        /libcrypto/        => formula_opt_lib("openssl")/"libcrypto.dylib",
+        /libck/            => formula_opt_lib("ck")/"libck.dylib",
+      }.each do |pattern, new_name|
+        old_name = dylibs.grep(pattern).first
+        MachO::Tools.change_install_name("relay.so", old_name, new_name.to_s) if old_name
       end
 
       # Apply ad-hoc code signature
-      MachO.codesign!("relay.so") if Hardware::CPU.arm?
+      MachO.codesign!("relay.so")
 
       # move extension file
       lib.install "relay.so"

--- a/Formula/relay@8.2.rb
+++ b/Formula/relay@8.2.rb
@@ -8,15 +8,9 @@ class RelayAT82 < Formula
     url "https://github.com/cachewerk/relay.git", tag: "v0.40.0"
 
     resource "ext-relay" do
-      if Hardware::CPU.arm?
-        # stable: php8.2-darwin-arm64
-        url "https://builds.r2.relay.so/v0.40.0/relay-v0.40.0-php8.2-darwin-arm64.tar.gz"
-        sha256 "21ea0e6159e9d2c583f96c3f77c0f00de9aa5efffa9de116137836b711c4b848"
-      else
-        # stable: php8.2-darwin-x86-64
-        url "https://builds.r2.relay.so/v0.7.0/relay-v0.7.0-php8.2-darwin-x86-64.tar.gz"
-        sha256 "1f7116164fd9984f9f494f7c9cb1f2ab5a75bed53f4d8a76f0eccd2e8c7a9186"
-      end
+      # stable: php8.2-darwin-arm64
+      url "https://builds.r2.relay.so/v0.40.0/relay-v0.40.0-php8.2-darwin-arm64.tar.gz"
+      sha256 "21ea0e6159e9d2c583f96c3f77c0f00de9aa5efffa9de116137836b711c4b848"
     end
   end
 
@@ -24,13 +18,8 @@ class RelayAT82 < Formula
     url "https://github.com/cachewerk/relay.git", branch: "main"
 
     resource "ext-relay" do
-      if Hardware::CPU.arm?
-        # head: php8.2-darwin-arm64
-        url "https://builds.r2.relay.so/dev/relay-dev-php8.2-darwin-arm64.tar.gz"
-      else
-        # head: php8.2-darwin-x86-64
-        url "https://builds.r2.relay.so/dev/relay-dev-php8.2-darwin-x86-64.tar.gz"
-      end
+      # head: php8.2-darwin-arm64
+      url "https://builds.r2.relay.so/dev/relay-dev-php8.2-darwin-arm64.tar.gz"
     end
   end
 
@@ -38,9 +27,7 @@ class RelayAT82 < Formula
 
   depends_on "concurrencykit"
   depends_on "hiredis"
-  depends_on "lz4"
   depends_on "php@8.2"
-  depends_on "zstd"
 
   def conf_dir
     Pathname(Utils.safe_popen_read(formula_opt_bin("php@8.2")/"php-config", "--ini-dir").chomp)
@@ -67,21 +54,19 @@ class RelayAT82 < Formula
       # relink dependencies
       dylibs = MachO::Tools.dylibs("relay.so")
 
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis\./).first, (formula_opt_lib("hiredis")/"libhiredis.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis_ssl\./).first, (formula_opt_lib("hiredis")/"libhiredis_ssl.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libssl/).first, (formula_opt_lib("openssl")/"libssl.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libcrypto/).first, (formula_opt_lib("openssl")/"libcrypto.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libzstd/).first, (formula_opt_lib("zstd")/"libzstd.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/liblz4/).first, (formula_opt_lib("lz4")/"liblz4.dylib").to_s)
-
-      if Hardware::CPU.intel?
-        MachO::Tools.change_install_name("relay.so", dylibs.grep(/libck/).first, (formula_opt_lib("ck")/"libck.dylib").to_s)
+      {
+        /libhiredis\./     => formula_opt_lib("hiredis")/"libhiredis.dylib",
+        /libhiredis_ssl\./ => formula_opt_lib("hiredis")/"libhiredis_ssl.dylib",
+        /libssl/           => formula_opt_lib("openssl")/"libssl.dylib",
+        /libcrypto/        => formula_opt_lib("openssl")/"libcrypto.dylib",
+        /libck/            => formula_opt_lib("ck")/"libck.dylib",
+      }.each do |pattern, new_name|
+        old_name = dylibs.grep(pattern).first
+        MachO::Tools.change_install_name("relay.so", old_name, new_name.to_s) if old_name
       end
 
       # Apply ad-hoc code signature
-      MachO.codesign!("relay.so") if Hardware::CPU.arm?
+      MachO.codesign!("relay.so")
 
       # move extension file
       lib.install "relay.so"

--- a/Formula/relay@8.3.rb
+++ b/Formula/relay@8.3.rb
@@ -8,15 +8,9 @@ class RelayAT83 < Formula
     url "https://github.com/cachewerk/relay.git", tag: "v0.40.0"
 
     resource "ext-relay" do
-      if Hardware::CPU.arm?
-        # stable: php8.3-darwin-arm64
-        url "https://builds.r2.relay.so/v0.40.0/relay-v0.40.0-php8.3-darwin-arm64.tar.gz"
-        sha256 "390004aed36d088a4d9b3d986df84b27db9e1fb9a165aea3d58b5cb87d3439bf"
-      else
-        # stable: php8.3-darwin-x86-64
-        url "https://builds.r2.relay.so/v0.7.0/relay-v0.7.0-php8.3-darwin-x86-64.tar.gz"
-        sha256 "bd94daaeb6aea3b53624b397502c26bb687ebc1b566699b4437f4a92e2f25606"
-      end
+      # stable: php8.3-darwin-arm64
+      url "https://builds.r2.relay.so/v0.40.0/relay-v0.40.0-php8.3-darwin-arm64.tar.gz"
+      sha256 "390004aed36d088a4d9b3d986df84b27db9e1fb9a165aea3d58b5cb87d3439bf"
     end
   end
 
@@ -24,13 +18,8 @@ class RelayAT83 < Formula
     url "https://github.com/cachewerk/relay.git", branch: "main"
 
     resource "ext-relay" do
-      if Hardware::CPU.arm?
-        # head: php8.3-darwin-arm64
-        url "https://builds.r2.relay.so/dev/relay-dev-php8.3-darwin-arm64.tar.gz"
-      else
-        # head: php8.3-darwin-x86-64
-        url "https://builds.r2.relay.so/dev/relay-dev-php8.3-darwin-x86-64.tar.gz"
-      end
+      # head: php8.3-darwin-arm64
+      url "https://builds.r2.relay.so/dev/relay-dev-php8.3-darwin-arm64.tar.gz"
     end
   end
 
@@ -38,9 +27,7 @@ class RelayAT83 < Formula
 
   depends_on "concurrencykit"
   depends_on "hiredis"
-  depends_on "lz4"
   depends_on "php@8.3"
-  depends_on "zstd"
 
   def conf_dir
     Pathname(Utils.safe_popen_read(formula_opt_bin("php@8.3")/"php-config", "--ini-dir").chomp)
@@ -67,21 +54,19 @@ class RelayAT83 < Formula
       # relink dependencies
       dylibs = MachO::Tools.dylibs("relay.so")
 
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis\./).first, (formula_opt_lib("hiredis")/"libhiredis.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis_ssl\./).first, (formula_opt_lib("hiredis")/"libhiredis_ssl.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libssl/).first, (formula_opt_lib("openssl")/"libssl.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libcrypto/).first, (formula_opt_lib("openssl")/"libcrypto.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libzstd/).first, (formula_opt_lib("zstd")/"libzstd.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/liblz4/).first, (formula_opt_lib("lz4")/"liblz4.dylib").to_s)
-
-      if Hardware::CPU.intel?
-        MachO::Tools.change_install_name("relay.so", dylibs.grep(/libck/).first, (formula_opt_lib("ck")/"libck.dylib").to_s)
+      {
+        /libhiredis\./     => formula_opt_lib("hiredis")/"libhiredis.dylib",
+        /libhiredis_ssl\./ => formula_opt_lib("hiredis")/"libhiredis_ssl.dylib",
+        /libssl/           => formula_opt_lib("openssl")/"libssl.dylib",
+        /libcrypto/        => formula_opt_lib("openssl")/"libcrypto.dylib",
+        /libck/            => formula_opt_lib("ck")/"libck.dylib",
+      }.each do |pattern, new_name|
+        old_name = dylibs.grep(pattern).first
+        MachO::Tools.change_install_name("relay.so", old_name, new_name.to_s) if old_name
       end
 
       # Apply ad-hoc code signature
-      MachO.codesign!("relay.so") if Hardware::CPU.arm?
+      MachO.codesign!("relay.so")
 
       # move extension file
       lib.install "relay.so"

--- a/Formula/relay@8.4.rb
+++ b/Formula/relay@8.4.rb
@@ -8,15 +8,9 @@ class RelayAT84 < Formula
     url "https://github.com/cachewerk/relay.git", tag: "v0.40.0"
 
     resource "ext-relay" do
-      if Hardware::CPU.arm?
-        # stable: php8.4-darwin-arm64
-        url "https://builds.r2.relay.so/v0.40.0/relay-v0.40.0-php8.4-darwin-arm64.tar.gz"
-        sha256 "58fdbcdc925f5d04e77db9f22dfb348fc20871d0c67e5085b55d16c4157f24b5"
-      else
-        # stable: php8.4-darwin-x86-64
-        url "https://builds.r2.relay.so/v0.9.0/relay-v0.7.0-php8.4-darwin-x86-64.tar.gz"
-        sha256 "bd94daaeb6aea3b53624b397502c26bb687ebc1b566699b4437f4a92e2f25606"
-      end
+      # stable: php8.4-darwin-arm64
+      url "https://builds.r2.relay.so/v0.40.0/relay-v0.40.0-php8.4-darwin-arm64.tar.gz"
+      sha256 "58fdbcdc925f5d04e77db9f22dfb348fc20871d0c67e5085b55d16c4157f24b5"
     end
   end
 
@@ -24,21 +18,14 @@ class RelayAT84 < Formula
     url "https://github.com/cachewerk/relay.git", branch: "main"
 
     resource "ext-relay" do
-      if Hardware::CPU.arm?
-        # head: php8.4-darwin-arm64
-        url "https://builds.r2.relay.so/dev/relay-dev-php8.4-darwin-arm64.tar.gz"
-      else
-        # head: php8.4-darwin-x86-64
-        url "https://builds.r2.relay.so/dev/relay-dev-php8.4-darwin-x86-64.tar.gz"
-      end
+      # head: php8.4-darwin-arm64
+      url "https://builds.r2.relay.so/dev/relay-dev-php8.4-darwin-arm64.tar.gz"
     end
   end
 
   depends_on "concurrencykit"
   depends_on "hiredis"
-  depends_on "lz4"
   depends_on "php"
-  depends_on "zstd"
 
   def conf_dir
     Pathname(Utils.safe_popen_read(formula_opt_bin("php")/"php-config", "--ini-dir").chomp)
@@ -63,21 +50,19 @@ class RelayAT84 < Formula
       # relink dependencies
       dylibs = MachO::Tools.dylibs("relay.so")
 
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis\./).first, (formula_opt_lib("hiredis")/"libhiredis.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis_ssl\./).first, (formula_opt_lib("hiredis")/"libhiredis_ssl.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libssl/).first, (formula_opt_lib("openssl")/"libssl.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libcrypto/).first, (formula_opt_lib("openssl")/"libcrypto.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libzstd/).first, (formula_opt_lib("zstd")/"libzstd.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/liblz4/).first, (formula_opt_lib("lz4")/"liblz4.dylib").to_s)
-
-      if Hardware::CPU.intel?
-        MachO::Tools.change_install_name("relay.so", dylibs.grep(/libck/).first, (formula_opt_lib("ck")/"libck.dylib").to_s)
+      {
+        /libhiredis\./     => formula_opt_lib("hiredis")/"libhiredis.dylib",
+        /libhiredis_ssl\./ => formula_opt_lib("hiredis")/"libhiredis_ssl.dylib",
+        /libssl/           => formula_opt_lib("openssl")/"libssl.dylib",
+        /libcrypto/        => formula_opt_lib("openssl")/"libcrypto.dylib",
+        /libck/            => formula_opt_lib("ck")/"libck.dylib",
+      }.each do |pattern, new_name|
+        old_name = dylibs.grep(pattern).first
+        MachO::Tools.change_install_name("relay.so", old_name, new_name.to_s) if old_name
       end
 
       # Apply ad-hoc code signature
-      MachO.codesign!("relay.so") if Hardware::CPU.arm?
+      MachO.codesign!("relay.so")
 
       # move extension file
       lib.install "relay.so"


### PR DESCRIPTION
Relay no longer publishes darwin x86-64 builds — `artifacts.json` for v0.40.0 lists only `arm64`, which is why the x86-64 URLs in every formula were still pinned to v0.7.0/v0.9.0.

This also fixes `brew install relay` failing on v0.40.0 with:

```
Error: An exception occurred within a child process:
  MachO::DylibUnknownError: No such dylib name:
```

### What changed

- **Resource blocks** no longer branch on `Hardware::CPU.arm?`; only the arm64 URL remains, keeping the `# stable:`/`# head:` marker comments the bump workflow relies on.
- **Fixed the relink failure.** As of v0.40.0 `zstd` and `lz4` are statically linked into `relay.so`, so `dylibs.grep(/libzstd/).first` returns `nil` and `MachO::Tools.change_install_name` raises `DylibUnknownError` with an empty name. Relinking is now a loop that skips any dylib absent from the binary, so a future statically-linked dependency won't break installs again.
- **Dropped `depends_on "zstd"` and `depends_on "lz4"`.** Verified against all six v0.40.0 arm64 builds and the dev/head build: zero `libzstd`/`liblz4` load commands, symbols now defined in-binary. `php --ri relay` still reports `Available compression => lzf, zstd, lz4`.
- **`libck` is relinked unconditionally** rather than only on Intel, so `relay.so` points at `/opt/homebrew/opt/ck/lib/libck.dylib` instead of relying on the `HOMEBREW_PREFIX/lib` symlink farm.
- **`MachO.codesign!` is unconditional** (was `if Hardware::CPU.arm?`).
- **`bump-stable.yml`**: `jq` now filters `.arch == "arm64"` so it stops downloading x86-64 artifacts, and the `gsed` insertions emit 6-space indentation to match the un-nested `url`/`sha256` lines.

### Verification

`brew upgrade relay` now succeeds (0.30.0 → 0.40.0):

```
$ otool -L /opt/homebrew/opt/relay/lib/relay.so
	/opt/homebrew/opt/hiredis/lib/libhiredis_ssl.dylib
	/opt/homebrew/opt/hiredis/lib/libhiredis.dylib
	/opt/homebrew/opt/openssl/lib/libssl.dylib
	/opt/homebrew/opt/openssl/lib/libcrypto.dylib
	/opt/homebrew/opt/ck/lib/libck.dylib
	/usr/lib/libSystem.B.dylib

$ codesign -v /opt/homebrew/opt/relay/lib/relay.so   # valid

$ php --ri relay
Relay Version => 0.40.0
Available serializers => php, json, igbinary, msgpack
Available compression => lzf, zstd, lz4
```

`brew style` passes on all six formulae with the same `--except-cops` the workflow uses.

### Not included

`relay@8.0` through `relay@8.3` fail to load entirely — `caveats` interpolates `#{pecl}`, but `pecl` is a local variable defined inside `install`:

```
Error: undefined local variable or method 'pecl' for an instance of ...::RelayAT83
```

This predates these changes (`relay@8.4` and `relay.rb` use a literal `pecl` instead), so it's left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)