### PR TITLE
Skip relinking dylibs missing from the binary

### DIFF
--- a/Formula/relay.rb
+++ b/Formula/relay.rb
@@ -63,17 +63,17 @@ class Relay < Formula
       # relink dependencies
       dylibs = MachO::Tools.dylibs("relay.so")
 
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis\./).first, (formula_opt_lib("hiredis")/"libhiredis.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis_ssl\./).first, (formula_opt_lib("hiredis")/"libhiredis_ssl.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libssl/).first, (formula_opt_lib("openssl")/"libssl.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libcrypto/).first, (formula_opt_lib("openssl")/"libcrypto.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libzstd/).first, (formula_opt_lib("zstd")/"libzstd.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/liblz4/).first, (formula_opt_lib("lz4")/"liblz4.dylib").to_s)
-
-      if Hardware::CPU.intel?
-        MachO::Tools.change_install_name("relay.so", dylibs.grep(/libck/).first, (formula_opt_lib("ck")/"libck.dylib").to_s)
+      {
+        /libhiredis\./     => formula_opt_lib("hiredis")/"libhiredis.dylib",
+        /libhiredis_ssl\./ => formula_opt_lib("hiredis")/"libhiredis_ssl.dylib",
+        /libssl/           => formula_opt_lib("openssl")/"libssl.dylib",
+        /libcrypto/        => formula_opt_lib("openssl")/"libcrypto.dylib",
+        /libzstd/          => formula_opt_lib("zstd")/"libzstd.dylib",
+        /liblz4/           => formula_opt_lib("lz4")/"liblz4.dylib",
+        /libck/            => formula_opt_lib("ck")/"libck.dylib",
+      }.each do |pattern, new_name|
+        old_name = dylibs.grep(pattern).first
+        MachO::Tools.change_install_name("relay.so", old_name, new_name.to_s) if old_name
       end
 
       # Apply ad-hoc code signature

--- a/Formula/relay@8.0.rb
+++ b/Formula/relay@8.0.rb
@@ -67,17 +67,17 @@ class RelayAT80 < Formula
       # relink dependencies
       dylibs = MachO::Tools.dylibs("relay.so")
 
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis\./).first, (formula_opt_lib("hiredis")/"libhiredis.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis_ssl\./).first, (formula_opt_lib("hiredis")/"libhiredis_ssl.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libssl/).first, (formula_opt_lib("openssl")/"libssl.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libcrypto/).first, (formula_opt_lib("openssl")/"libcrypto.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libzstd/).first, (formula_opt_lib("zstd")/"libzstd.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/liblz4/).first, (formula_opt_lib("lz4")/"liblz4.dylib").to_s)
-
-      if Hardware::CPU.intel?
-        MachO::Tools.change_install_name("relay.so", dylibs.grep(/libck/).first, (formula_opt_lib("ck")/"libck.dylib").to_s)
+      {
+        /libhiredis\./     => formula_opt_lib("hiredis")/"libhiredis.dylib",
+        /libhiredis_ssl\./ => formula_opt_lib("hiredis")/"libhiredis_ssl.dylib",
+        /libssl/           => formula_opt_lib("openssl")/"libssl.dylib",
+        /libcrypto/        => formula_opt_lib("openssl")/"libcrypto.dylib",
+        /libzstd/          => formula_opt_lib("zstd")/"libzstd.dylib",
+        /liblz4/           => formula_opt_lib("lz4")/"liblz4.dylib",
+        /libck/            => formula_opt_lib("ck")/"libck.dylib",
+      }.each do |pattern, new_name|
+        old_name = dylibs.grep(pattern).first
+        MachO::Tools.change_install_name("relay.so", old_name, new_name.to_s) if old_name
       end
 
       # Apply ad-hoc code signature

--- a/Formula/relay@8.1.rb
+++ b/Formula/relay@8.1.rb
@@ -67,17 +67,17 @@ class RelayAT81 < Formula
       # relink dependencies
       dylibs = MachO::Tools.dylibs("relay.so")
 
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis\./).first, (formula_opt_lib("hiredis")/"libhiredis.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis_ssl\./).first, (formula_opt_lib("hiredis")/"libhiredis_ssl.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libssl/).first, (formula_opt_lib("openssl")/"libssl.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libcrypto/).first, (formula_opt_lib("openssl")/"libcrypto.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libzstd/).first, (formula_opt_lib("zstd")/"libzstd.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/liblz4/).first, (formula_opt_lib("lz4")/"liblz4.dylib").to_s)
-
-      if Hardware::CPU.intel?
-        MachO::Tools.change_install_name("relay.so", dylibs.grep(/libck/).first, (formula_opt_lib("ck")/"libck.dylib").to_s)
+      {
+        /libhiredis\./     => formula_opt_lib("hiredis")/"libhiredis.dylib",
+        /libhiredis_ssl\./ => formula_opt_lib("hiredis")/"libhiredis_ssl.dylib",
+        /libssl/           => formula_opt_lib("openssl")/"libssl.dylib",
+        /libcrypto/        => formula_opt_lib("openssl")/"libcrypto.dylib",
+        /libzstd/          => formula_opt_lib("zstd")/"libzstd.dylib",
+        /liblz4/           => formula_opt_lib("lz4")/"liblz4.dylib",
+        /libck/            => formula_opt_lib("ck")/"libck.dylib",
+      }.each do |pattern, new_name|
+        old_name = dylibs.grep(pattern).first
+        MachO::Tools.change_install_name("relay.so", old_name, new_name.to_s) if old_name
       end
 
       # Apply ad-hoc code signature

--- a/Formula/relay@8.2.rb
+++ b/Formula/relay@8.2.rb
@@ -67,17 +67,17 @@ class RelayAT82 < Formula
       # relink dependencies
       dylibs = MachO::Tools.dylibs("relay.so")
 
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis\./).first, (formula_opt_lib("hiredis")/"libhiredis.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis_ssl\./).first, (formula_opt_lib("hiredis")/"libhiredis_ssl.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libssl/).first, (formula_opt_lib("openssl")/"libssl.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libcrypto/).first, (formula_opt_lib("openssl")/"libcrypto.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libzstd/).first, (formula_opt_lib("zstd")/"libzstd.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/liblz4/).first, (formula_opt_lib("lz4")/"liblz4.dylib").to_s)
-
-      if Hardware::CPU.intel?
-        MachO::Tools.change_install_name("relay.so", dylibs.grep(/libck/).first, (formula_opt_lib("ck")/"libck.dylib").to_s)
+      {
+        /libhiredis\./     => formula_opt_lib("hiredis")/"libhiredis.dylib",
+        /libhiredis_ssl\./ => formula_opt_lib("hiredis")/"libhiredis_ssl.dylib",
+        /libssl/           => formula_opt_lib("openssl")/"libssl.dylib",
+        /libcrypto/        => formula_opt_lib("openssl")/"libcrypto.dylib",
+        /libzstd/          => formula_opt_lib("zstd")/"libzstd.dylib",
+        /liblz4/           => formula_opt_lib("lz4")/"liblz4.dylib",
+        /libck/            => formula_opt_lib("ck")/"libck.dylib",
+      }.each do |pattern, new_name|
+        old_name = dylibs.grep(pattern).first
+        MachO::Tools.change_install_name("relay.so", old_name, new_name.to_s) if old_name
       end
 
       # Apply ad-hoc code signature

--- a/Formula/relay@8.3.rb
+++ b/Formula/relay@8.3.rb
@@ -67,17 +67,17 @@ class RelayAT83 < Formula
       # relink dependencies
       dylibs = MachO::Tools.dylibs("relay.so")
 
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis\./).first, (formula_opt_lib("hiredis")/"libhiredis.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis_ssl\./).first, (formula_opt_lib("hiredis")/"libhiredis_ssl.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libssl/).first, (formula_opt_lib("openssl")/"libssl.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libcrypto/).first, (formula_opt_lib("openssl")/"libcrypto.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libzstd/).first, (formula_opt_lib("zstd")/"libzstd.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/liblz4/).first, (formula_opt_lib("lz4")/"liblz4.dylib").to_s)
-
-      if Hardware::CPU.intel?
-        MachO::Tools.change_install_name("relay.so", dylibs.grep(/libck/).first, (formula_opt_lib("ck")/"libck.dylib").to_s)
+      {
+        /libhiredis\./     => formula_opt_lib("hiredis")/"libhiredis.dylib",
+        /libhiredis_ssl\./ => formula_opt_lib("hiredis")/"libhiredis_ssl.dylib",
+        /libssl/           => formula_opt_lib("openssl")/"libssl.dylib",
+        /libcrypto/        => formula_opt_lib("openssl")/"libcrypto.dylib",
+        /libzstd/          => formula_opt_lib("zstd")/"libzstd.dylib",
+        /liblz4/           => formula_opt_lib("lz4")/"liblz4.dylib",
+        /libck/            => formula_opt_lib("ck")/"libck.dylib",
+      }.each do |pattern, new_name|
+        old_name = dylibs.grep(pattern).first
+        MachO::Tools.change_install_name("relay.so", old_name, new_name.to_s) if old_name
       end
 
       # Apply ad-hoc code signature

--- a/Formula/relay@8.4.rb
+++ b/Formula/relay@8.4.rb
@@ -63,17 +63,17 @@ class RelayAT84 < Formula
       # relink dependencies
       dylibs = MachO::Tools.dylibs("relay.so")
 
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis\./).first, (formula_opt_lib("hiredis")/"libhiredis.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libhiredis_ssl\./).first, (formula_opt_lib("hiredis")/"libhiredis_ssl.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libssl/).first, (formula_opt_lib("openssl")/"libssl.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libcrypto/).first, (formula_opt_lib("openssl")/"libcrypto.dylib").to_s)
-
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/libzstd/).first, (formula_opt_lib("zstd")/"libzstd.dylib").to_s)
-      MachO::Tools.change_install_name("relay.so", dylibs.grep(/liblz4/).first, (formula_opt_lib("lz4")/"liblz4.dylib").to_s)
-
-      if Hardware::CPU.intel?
-        MachO::Tools.change_install_name("relay.so", dylibs.grep(/libck/).first, (formula_opt_lib("ck")/"libck.dylib").to_s)
+      {
+        /libhiredis\./     => formula_opt_lib("hiredis")/"libhiredis.dylib",
+        /libhiredis_ssl\./ => formula_opt_lib("hiredis")/"libhiredis_ssl.dylib",
+        /libssl/           => formula_opt_lib("openssl")/"libssl.dylib",
+        /libcrypto/        => formula_opt_lib("openssl")/"libcrypto.dylib",
+        /libzstd/          => formula_opt_lib("zstd")/"libzstd.dylib",
+        /liblz4/           => formula_opt_lib("lz4")/"liblz4.dylib",
+        /libck/            => formula_opt_lib("ck")/"libck.dylib",
+      }.each do |pattern, new_name|
+        old_name = dylibs.grep(pattern).first
+        MachO::Tools.change_install_name("relay.so", old_name, new_name.to_s) if old_name
       end
 
       # Apply ad-hoc code signature


### PR DESCRIPTION
`brew install relay` fails on v0.40.0 with:

```
Error: An exception occurred within a child process:
  MachO::DylibUnknownError: No such dylib name:
```

As of v0.40.0 `zstd` and `lz4` are statically linked into the arm64 `relay.so`, so `dylibs.grep(/libzstd/).first` returns `nil`, and `MachO::Tools.change_install_name` raises with an empty name:

```
=== v0.30.0 relay.so ===          === v0.40.0 relay.so ===
libhiredis_ssl.1.4.0.dylib        libhiredis_ssl.1.4.0.dylib
libhiredis.1.4.0.dylib            libhiredis.1.4.0.dylib
libssl.3.dylib                    libssl.3.dylib
libcrypto.3.dylib                 libcrypto.3.dylib
libck.0.dylib                     libck.0.dylib
libzstd.1.dylib          <- gone  libSystem.B.dylib
liblz4.1.dylib           <- gone
libSystem.B.dylib
```

Relinking is now a table + loop that skips any dylib absent from the binary, so the older Intel builds — which still link `zstd`/`lz4` dynamically — keep working, and a future statically-linked dependency won't break installs again. The `zstd` and `lz4` dependencies are kept for that reason.

Confirmed across all six v0.40.0 arm64 builds and the dev/head build: zero `libzstd`/`liblz4` load commands. `php --ri relay` still reports `Available compression => lzf, zstd, lz4`.

One behaviour change beyond the fix: `libck` is relinked on both architectures rather than only on Intel, so `relay.so` points at `/opt/homebrew/opt/ck/lib/libck.dylib` instead of relying on the `HOMEBREW_PREFIX/lib` symlink farm. Happy to make it Intel-only again if that is preferred.

### Verification

```
$ brew reinstall relay
🍺  /opt/homebrew/Cellar/relay/0.40.0

$ otool -L /opt/homebrew/opt/relay/lib/relay.so
	/opt/homebrew/opt/hiredis/lib/libhiredis_ssl.dylib
	/opt/homebrew/opt/hiredis/lib/libhiredis.dylib
	/opt/homebrew/opt/openssl/lib/libssl.dylib
	/opt/homebrew/opt/openssl/lib/libcrypto.dylib
	/opt/homebrew/opt/ck/lib/libck.dylib
	/usr/lib/libSystem.B.dylib

$ codesign -v /opt/homebrew/opt/relay/lib/relay.so   # valid

$ php --ri relay
Relay Version => 0.40.0
Available serializers => php, json, igbinary, msgpack
Available compression => lzf, zstd, lz4
```

`brew style` passes on all six formulae with the same `--except-cops` the bump workflow uses.

### Unrelated issues found along the way

Neither is touched here.

1. **The Intel URLs for PHP 8.4 and 8.5 have never resolved.** v0.7.0 was the last release to publish darwin x86-64 builds and it only went up to PHP 8.3, so `relay.rb` and `relay@8.4.rb` point at a `v0.9.0/relay-v0.7.0-...` path that 404s. `relay@8.0`–`relay@8.3` are fine (200).

2. **`relay@8.0` through `relay@8.3` fail to load entirely.** `caveats` interpolates `#{pecl}`, but `pecl` is a local variable defined inside `install`:

   ```
   Error: undefined local variable or method 'pecl' for an instance of ...::RelayAT83
   ```

   `relay@8.4` and `relay.rb` use a literal `pecl` instead, so they are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)